### PR TITLE
docs: fix typo in getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ included in our repository in the `COPYING` file.
 ## Join our Discord server
 
 Join Polygon community  – share your ideas or just say hi over on [Polygon Community Discord](https://discord.com/invite/0xPolygonCommunity) or on [Polygon R&D Discord](https://discord.com/invite/0xpolygonrnd).
+docs: fixed typo in getting started section


### PR DESCRIPTION
Corrected a small typo in the getting started section of README. 
Docs only, no code changes.
